### PR TITLE
ci: anchor test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,33 @@
+name: test
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Anchor Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get solana version
+        id: solana
+        run: |
+          SOLANA_VERSION="$(awk '/solana_version =/ { print substr($3, 2, length($3)-2) }' Anchor.toml)"
+          echo "::set-output name=version::${SOLANA_VERSION}"
+      - name: Get anchor version
+        id: anchor
+        run: |
+          ANCHOR_VERSION="$(awk '/anchor_version =/ { print substr($3, 2, length($3)-2) }' Anchor.toml)"
+          echo "::set-output name=version::${ANCHOR_VERSION}"
+      - uses: metadaoproject/anchor-test@c47c46486d1a62b0b22419163d7f7bfae570c390
+        with:
+          anchor-version: "${{steps.anchor.outputs.version}}"
+          solana-cli-version: "${{steps.solana.outputs.version}}"
+
+      - run: cargo fmt --check --all
+      - run: cargo clippy
+      - run: cargo test

--- a/Anchor.toml
+++ b/Anchor.toml
@@ -48,7 +48,7 @@ address = "dxZtypiKT5D9LYzdPxjvSZER9MgYfeRVU5qpMTMTRs4"
 filename = "tests/accounts/core_bridge_testnet/guardian_set_0_mock.json"
 
 [scripts]
-test = "npx tsc --noEmit && yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/solana-world-id-onchain-template.ts"
+test = "npx tsc --noEmit && npx ts-mocha -p ./tsconfig.json -t 1000000 tests/solana-world-id-onchain-template.ts"
 
 [test]
 upgradeable = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,20 +823,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "groth16-solana"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc65a9ef90161a41b67cd4611e113d09f3819a1d488e4effafde92fca70861d"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "solana-program",
- "thiserror",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,12 +854,6 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -1616,14 +1596,7 @@ name = "solana-world-id-onchain-template"
 version = "0.1.0"
 dependencies = [
  "anchor-lang",
- "cfg-if",
  "ethnum",
- "groth16-solana",
- "hex",
- "solana-program",
- "wormhole-query-sdk",
- "wormhole-solana-consts",
- "wormhole-solana-utils",
 ]
 
 [[package]]
@@ -1963,34 +1936,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wormhole-query-sdk"
-version = "0.0.1"
-source = "git+https://github.com/wormholelabs-xyz/wormhole-query-sdk-rust?rev=0f34cb470f4e3137b53aa91adcbb0c7def280925#0f34cb470f4e3137b53aa91adcbb0c7def280925"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "wormhole-solana-consts"
-version = "0.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ae70b3233a1d2e799276528ad7ec0a55c9929f8eae41683a5d6f0e8ba37649"
-dependencies = [
- "cfg-if",
- "solana-program",
-]
-
-[[package]]
-name = "wormhole-solana-utils"
-version = "0.3.0-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49bd1af023d73c6d6538cb6d9ea86111dac109ae134f45f7930425e372bf9cf"
-dependencies = [
- "anchor-lang",
- "solana-program",
 ]
 
 [[package]]

--- a/programs/solana-world-id-onchain-template/Cargo.toml
+++ b/programs/solana-world-id-onchain-template/Cargo.toml
@@ -9,22 +9,13 @@ crate-type = ["cdylib", "lib"]
 name = "solana_world_id_onchain_template"
 
 [features]
-default = ["mainnet"]
+default = []
 cpi = ["no-entrypoint"]
 no-entrypoint = []
 no-idl = []
 no-log-ix-name = []
-mainnet = ["wormhole-solana-consts/mainnet"]
-testnet = ["wormhole-solana-consts/testnet"]
 idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
 anchor-lang = "0.30.1"
-cfg-if = "1.0"
-wormhole-solana-consts = {version = "0.3.0-alpha.1"}
-wormhole-solana-utils = {version = "0.3.0-alpha.1"}
-wormhole-query-sdk = { git = "https://github.com/wormholelabs-xyz/wormhole-query-sdk-rust", version = "0.0.1", rev = "0f34cb470f4e3137b53aa91adcbb0c7def280925" }
-groth16-solana = "0.0.3"
-solana-program = "1.18.17"
 ethnum = "1.3.2"
-hex = "0.4.3"

--- a/programs/solana-world-id-onchain-template/src/instructions/verify_and_execute.rs
+++ b/programs/solana-world-id-onchain-template/src/instructions/verify_and_execute.rs
@@ -55,8 +55,7 @@ fn hash_to_field(input: &[u8]) -> [u8; 32] {
     let hash_result = hash(input).to_bytes();
     let big_int: U256 = U256::from_be_bytes(hash_result);
     let shifted: U256 = big_int >> 8;
-    let result = shifted.to_be_bytes();
-    result
+    shifted.to_be_bytes()
 }
 
 fn app_id_action_to_external_nullifier_hash(app_id: &str, action: &str) -> [u8; 32] {

--- a/tests/helpers/latestRoot.ts
+++ b/tests/helpers/latestRoot.ts
@@ -1,0 +1,12 @@
+// modified from https://github.com/wormhole-foundation/wormhole/blob/main/sdk/js/src/solana/wormhole/accounts/guardianSet.ts
+import * as anchor from "@coral-xyz/anchor";
+
+export function deriveLatestRootKey(
+  worldIdProgramId: anchor.web3.PublicKey,
+  type: number
+): anchor.web3.PublicKey {
+  return anchor.web3.PublicKey.findProgramAddressSync(
+    [Buffer.from("LatestRoot"), Buffer.from([type])],
+    worldIdProgramId
+  )[0];
+}

--- a/tests/helpers/mockUpdateRoot.ts
+++ b/tests/helpers/mockUpdateRoot.ts
@@ -1,0 +1,61 @@
+import { Program } from "@coral-xyz/anchor";
+import { Keypair, PublicKey } from "@solana/web3.js";
+import {
+  EthCallQueryRequest,
+  EthCallQueryResponse,
+  QueryProxyMock,
+  QueryResponse,
+} from "@wormhole-foundation/wormhole-query-sdk";
+import { BN } from "bn.js";
+import { deriveLatestRootKey } from "./latestRoot";
+import { signaturesToSolanaArray } from "./signaturesToSolanaArray";
+import { SolanaWorldIdProgram } from "./solana_world_id_program";
+
+// This is a testing helper for posting roots to the Solana World ID Program so that groth16 proofs can be verified against them.
+export async function mockUpdateRoot(
+  program: Program<SolanaWorldIdProgram>,
+  rootHash: number[]
+) {
+  const slot = await program.provider.connection.getSlot();
+  const blockTime = new BN(
+    await program.provider.connection.getBlockTime(slot)
+  ).mul(new BN(1_000_000)); // seconds to microseconds;
+  const latestRootKey = deriveLatestRootKey(program.programId, 0);
+  const latestRoot = await program.account.latestRoot.fetch(latestRootKey);
+  // this is a query response from mainnet that can be used as the basis for an update
+  // https://github.com/wormholelabs-xyz/solana-world-id-program/blob/a52c055663f12871beace3024a2608c6fb8ce04d/tests/solana-world-id-program.ts#L266
+  const mockQueryResponse =
+    "010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000037010000002a010002010000002a0000000930783133363635613001f7134ce138832c1456f2a91d64621ee90c2bddea00000004d7b0fef1010002010000005500000000013665a0b4d1f4641086607c69154ed3a94cb8d37ff925a441f98057863ff02bf75e768400061d9d5184e9c0010000002001ba3a37ccad06a0a974a9813b989ceeb4b31d34d2b236e194a2c3c4698e0f2b";
+  const queryResponse = QueryResponse.from(mockQueryResponse);
+  const ethCallResponse = queryResponse.responses[0]
+    .response as EthCallQueryResponse;
+  // chain must be Sepolia
+  queryResponse.request.requests[0].chainId = 10002;
+  queryResponse.responses[0].chainId = 10002;
+  // contract must be the testnet World ID Identity Manager
+  (
+    queryResponse.request.requests[0].query as EthCallQueryRequest
+  ).callData[0].to = "0x928a514350A403e2f5e3288C102f6B1CCABeb37C";
+  // block number must be after the latest root
+  ethCallResponse.blockNumber =
+    BigInt(latestRoot.readBlockNumber.toString()) + BigInt(1);
+  // block time must be within allowed update staleness, set the current slot time
+  ethCallResponse.blockTime = BigInt(blockTime.toString());
+  ethCallResponse.results[0] = `0x${Buffer.from(rootHash).toString("hex")}`;
+  const bytes = queryResponse.serialize();
+  const signatures = new QueryProxyMock({}).sign(bytes);
+  const signatureData = signaturesToSolanaArray(signatures);
+  const signaturesKeypair = Keypair.generate();
+  await program.methods
+    .postSignatures(signatureData, signatureData.length)
+    .accounts({ guardianSignatures: signaturesKeypair.publicKey })
+    .signers([signaturesKeypair])
+    .rpc();
+  await program.methods
+    .updateRootWithQuery(Buffer.from(bytes), rootHash, 0)
+    .accountsPartial({
+      guardianSet: new PublicKey("dxZtypiKT5D9LYzdPxjvSZER9MgYfeRVU5qpMTMTRs4"), // mock guardian set in Anchor.toml
+      guardianSignatures: signaturesKeypair.publicKey,
+    })
+    .rpc();
+}

--- a/tests/helpers/signaturesToSolanaArray.ts
+++ b/tests/helpers/signaturesToSolanaArray.ts
@@ -1,0 +1,10 @@
+// TODO: PR to @wormhole-foundation/wormhole-query-sdk
+// GuardianSetSig expects the guardian index before the signature, the inverse of what the Query Proxy returns.
+// https://docs.rs/wormhole-raw-vaas/0.3.0-alpha.1/src/wormhole_raw_vaas/protocol.rs.html#220
+// https://github.com/wormhole-foundation/wormhole/blob/31b01629087c610c12fa8e84069786139dc0b6bd/node/cmd/ccq/http.go#L191
+export function signaturesToSolanaArray(signatures: string[]) {
+  return signatures.map((s) => [
+    ...Buffer.from(s.substring(130, 132), "hex"),
+    ...Buffer.from(s.substring(0, 130), "hex"),
+  ]);
+}

--- a/tests/helpers/solana_world_id_program.ts
+++ b/tests/helpers/solana_world_id_program.ts
@@ -1,0 +1,1382 @@
+/**
+ * Program IDL in camelCase format in order to be used in JS/TS.
+ *
+ * Note that this is only a type helper and is not the actual IDL. The original
+ * IDL can be found at `target/idl/solana_world_id_program.json`.
+ */
+export type SolanaWorldIdProgram = {
+  "address": "9QwAWx3TKg4CaTjHNhBefQeNSzEKDe2JDxL46F76tVDv",
+  "metadata": {
+    "name": "solanaWorldIdProgram",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "Created with Anchor"
+  },
+  "instructions": [
+    {
+      "name": "claimOwnership",
+      "discriminator": [
+        236,
+        166,
+        239,
+        222,
+        14,
+        45,
+        143,
+        254
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  67,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "upgradeLock",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  112,
+                  103,
+                  114,
+                  97,
+                  100,
+                  101,
+                  95,
+                  108,
+                  111,
+                  99,
+                  107
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "newOwner",
+          "signer": true
+        },
+        {
+          "name": "programData",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  124,
+                  255,
+                  24,
+                  248,
+                  7,
+                  150,
+                  208,
+                  255,
+                  225,
+                  244,
+                  56,
+                  157,
+                  121,
+                  39,
+                  45,
+                  3,
+                  230,
+                  56,
+                  4,
+                  46,
+                  37,
+                  39,
+                  124,
+                  197,
+                  125,
+                  184,
+                  111,
+                  162,
+                  164,
+                  27,
+                  84,
+                  229
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "bpfLoaderUpgradeableProgram",
+          "address": "BPFLoaderUpgradeab1e11111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "cleanUpRoot",
+      "discriminator": [
+        106,
+        202,
+        208,
+        50,
+        239,
+        7,
+        142,
+        41
+      ],
+      "accounts": [
+        {
+          "name": "root",
+          "docs": [
+            "This can be any expired root account.",
+            "The PDA check is omitted since this code allows cleaning up any root",
+            "and the discriminator will still be checked."
+          ],
+          "writable": true
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  67,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "refundRecipient",
+          "relations": [
+            "root"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "closeSignatures",
+      "discriminator": [
+        192,
+        65,
+        63,
+        117,
+        213,
+        138,
+        179,
+        190
+      ],
+      "accounts": [
+        {
+          "name": "guardianSignatures",
+          "writable": true
+        },
+        {
+          "name": "refundRecipient",
+          "signer": true,
+          "relations": [
+            "guardianSignatures"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize",
+      "discriminator": [
+        175,
+        175,
+        109,
+        31,
+        13,
+        152,
+        155,
+        237
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "deployer",
+          "signer": true
+        },
+        {
+          "name": "programData",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  124,
+                  255,
+                  24,
+                  248,
+                  7,
+                  150,
+                  208,
+                  255,
+                  225,
+                  244,
+                  56,
+                  157,
+                  121,
+                  39,
+                  45,
+                  3,
+                  230,
+                  56,
+                  4,
+                  46,
+                  37,
+                  39,
+                  124,
+                  197,
+                  125,
+                  184,
+                  111,
+                  162,
+                  164,
+                  27,
+                  84,
+                  229
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  67,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "latestRoot",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  76,
+                  97,
+                  116,
+                  101,
+                  115,
+                  116,
+                  82,
+                  111,
+                  111,
+                  116
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "args",
+          "type": {
+            "defined": {
+              "name": "initializeArgs"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "postSignatures",
+      "discriminator": [
+        138,
+        2,
+        53,
+        166,
+        45,
+        77,
+        137,
+        51
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "guardianSignatures",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "guardianSignatures",
+          "type": {
+            "vec": {
+              "array": [
+                "u8",
+                66
+              ]
+            }
+          }
+        },
+        {
+          "name": "totalSignatures",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "setAllowedUpdateStaleness",
+      "discriminator": [
+        97,
+        49,
+        167,
+        77,
+        179,
+        25,
+        243,
+        144
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  67,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "allowedUpdateStaleness",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "setRootExpiry",
+      "discriminator": [
+        2,
+        27,
+        190,
+        61,
+        106,
+        232,
+        172,
+        222
+      ],
+      "accounts": [
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  67,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "rootExpiry",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "transferOwnership",
+      "discriminator": [
+        65,
+        177,
+        215,
+        73,
+        53,
+        45,
+        99,
+        47
+      ],
+      "accounts": [
+        {
+          "name": "config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  67,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "owner",
+          "signer": true,
+          "relations": [
+            "config"
+          ]
+        },
+        {
+          "name": "newOwner"
+        },
+        {
+          "name": "upgradeLock",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  112,
+                  103,
+                  114,
+                  97,
+                  100,
+                  101,
+                  95,
+                  108,
+                  111,
+                  99,
+                  107
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "programData",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  124,
+                  255,
+                  24,
+                  248,
+                  7,
+                  150,
+                  208,
+                  255,
+                  225,
+                  244,
+                  56,
+                  157,
+                  121,
+                  39,
+                  45,
+                  3,
+                  230,
+                  56,
+                  4,
+                  46,
+                  37,
+                  39,
+                  124,
+                  197,
+                  125,
+                  184,
+                  111,
+                  162,
+                  164,
+                  27,
+                  84,
+                  229
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "bpfLoaderUpgradeableProgram",
+          "address": "BPFLoaderUpgradeab1e11111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "updateRootWithQuery",
+      "discriminator": [
+        137,
+        107,
+        96,
+        126,
+        245,
+        99,
+        23,
+        201
+      ],
+      "accounts": [
+        {
+          "name": "payer",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "guardianSet",
+          "docs": [
+            "Guardian set used for signature verification."
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  71,
+                  117,
+                  97,
+                  114,
+                  100,
+                  105,
+                  97,
+                  110,
+                  83,
+                  101,
+                  116
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "guardianSetIndex"
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                14,
+                10,
+                88,
+                154,
+                65,
+                165,
+                95,
+                189,
+                102,
+                197,
+                42,
+                71,
+                95,
+                45,
+                146,
+                166,
+                211,
+                220,
+                155,
+                71,
+                71,
+                17,
+                76,
+                185,
+                175,
+                130,
+                90,
+                152,
+                181,
+                69,
+                211,
+                206
+              ]
+            }
+          }
+        },
+        {
+          "name": "guardianSignatures",
+          "docs": [
+            "Stores unverified guardian signatures as they are too large to fit in the instruction data."
+          ],
+          "writable": true
+        },
+        {
+          "name": "root",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  82,
+                  111,
+                  111,
+                  116
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "rootHash"
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "latestRoot",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  76,
+                  97,
+                  116,
+                  101,
+                  115,
+                  116,
+                  82,
+                  111,
+                  111,
+                  116
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  0
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  67,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "refundRecipient",
+          "relations": [
+            "guardianSignatures"
+          ]
+        },
+        {
+          "name": "systemProgram",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "bytes",
+          "type": "bytes"
+        },
+        {
+          "name": "rootHash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "guardianSetIndex",
+          "type": "u32"
+        }
+      ]
+    },
+    {
+      "name": "verifyGroth16Proof",
+      "discriminator": [
+        54,
+        190,
+        59,
+        14,
+        54,
+        75,
+        155,
+        6
+      ],
+      "accounts": [
+        {
+          "name": "root",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  82,
+                  111,
+                  111,
+                  116
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "rootHash"
+              },
+              {
+                "kind": "arg",
+                "path": "verificationType"
+              }
+            ]
+          }
+        },
+        {
+          "name": "config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  67,
+                  111,
+                  110,
+                  102,
+                  105,
+                  103
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "rootHash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "verificationType",
+          "type": {
+            "array": [
+              "u8",
+              1
+            ]
+          }
+        },
+        {
+          "name": "signalHash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "nullifierHash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "externalNullifierHash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "proof",
+          "type": {
+            "array": [
+              "u8",
+              256
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "accounts": [
+    {
+      "name": "config",
+      "discriminator": [
+        155,
+        12,
+        170,
+        224,
+        30,
+        250,
+        204,
+        130
+      ]
+    },
+    {
+      "name": "guardianSignatures",
+      "discriminator": [
+        203,
+        184,
+        130,
+        157,
+        113,
+        14,
+        184,
+        83
+      ]
+    },
+    {
+      "name": "latestRoot",
+      "discriminator": [
+        12,
+        245,
+        231,
+        246,
+        191,
+        63,
+        169,
+        95
+      ]
+    },
+    {
+      "name": "root",
+      "discriminator": [
+        46,
+        159,
+        131,
+        37,
+        245,
+        84,
+        5,
+        9
+      ]
+    },
+    {
+      "name": "wormholeGuardianSet",
+      "discriminator": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6256,
+      "name": "writeAuthorityMismatch",
+      "msg": "writeAuthorityMismatch"
+    },
+    {
+      "code": 6257,
+      "name": "guardianSetExpired",
+      "msg": "guardianSetExpired"
+    },
+    {
+      "code": 6258,
+      "name": "invalidMessageHash",
+      "msg": "invalidMessageHash"
+    },
+    {
+      "code": 6259,
+      "name": "noQuorum",
+      "msg": "noQuorum"
+    },
+    {
+      "code": 6260,
+      "name": "invalidGuardianIndexNonIncreasing",
+      "msg": "invalidGuardianIndexNonIncreasing"
+    },
+    {
+      "code": 6261,
+      "name": "invalidGuardianIndexOutOfRange",
+      "msg": "invalidGuardianIndexOutOfRange"
+    },
+    {
+      "code": 6262,
+      "name": "invalidSignature",
+      "msg": "invalidSignature"
+    },
+    {
+      "code": 6263,
+      "name": "invalidGuardianKeyRecovery",
+      "msg": "invalidGuardianKeyRecovery"
+    },
+    {
+      "code": 6272,
+      "name": "failedToParseResponse",
+      "msg": "failedToParseResponse"
+    },
+    {
+      "code": 6273,
+      "name": "invalidNumberOfRequests",
+      "msg": "invalidNumberOfRequests"
+    },
+    {
+      "code": 6274,
+      "name": "invalidRequestChainId",
+      "msg": "invalidRequestChainId"
+    },
+    {
+      "code": 6275,
+      "name": "invalidRequestType",
+      "msg": "invalidRequestType"
+    },
+    {
+      "code": 6276,
+      "name": "invalidRequestCallDataLength",
+      "msg": "invalidRequestCallDataLength"
+    },
+    {
+      "code": 6277,
+      "name": "invalidRequestContract",
+      "msg": "invalidRequestContract"
+    },
+    {
+      "code": 6278,
+      "name": "invalidRequestSignature",
+      "msg": "invalidRequestSignature"
+    },
+    {
+      "code": 6279,
+      "name": "invalidNumberOfResponses",
+      "msg": "invalidNumberOfResponses"
+    },
+    {
+      "code": 6280,
+      "name": "invalidResponseChainId",
+      "msg": "invalidResponseChainId"
+    },
+    {
+      "code": 6281,
+      "name": "staleBlockNum",
+      "msg": "staleBlockNum"
+    },
+    {
+      "code": 6288,
+      "name": "staleBlockTime",
+      "msg": "staleBlockTime"
+    },
+    {
+      "code": 6289,
+      "name": "invalidResponseType",
+      "msg": "invalidResponseType"
+    },
+    {
+      "code": 6290,
+      "name": "invalidResponseResultsLength",
+      "msg": "invalidResponseResultsLength"
+    },
+    {
+      "code": 6291,
+      "name": "invalidResponseResultLength",
+      "msg": "invalidResponseResultLength"
+    },
+    {
+      "code": 6292,
+      "name": "rootHashMismatch",
+      "msg": "rootHashMismatch"
+    },
+    {
+      "code": 6293,
+      "name": "noopExpiryUpdate",
+      "msg": "noopExpiryUpdate"
+    },
+    {
+      "code": 6294,
+      "name": "rootUnexpired",
+      "msg": "rootUnexpired"
+    },
+    {
+      "code": 6512,
+      "name": "rootExpired",
+      "msg": "rootExpired"
+    },
+    {
+      "code": 6513,
+      "name": "createGroth16VerifierFailed",
+      "msg": "createGroth16VerifierFailed"
+    },
+    {
+      "code": 6514,
+      "name": "groth16ProofVerificationFailed",
+      "msg": "groth16ProofVerificationFailed"
+    },
+    {
+      "code": 10096,
+      "name": "invalidPendingOwner",
+      "msg": "invalidPendingOwner"
+    }
+  ],
+  "types": [
+    {
+      "name": "config",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "owner",
+            "docs": [
+              "Owner of the program."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "pendingOwner",
+            "docs": [
+              "Pending next owner (before claiming ownership)."
+            ],
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "rootExpiry",
+            "docs": [
+              "Time (in seconds) after which a root should be considered expired."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "allowedUpdateStaleness",
+            "docs": [
+              "Time (in seconds) after which an attempted update should be rejected."
+            ],
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "guardianSignatures",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "refundRecipient",
+            "docs": [
+              "Payer of this guardian signatures account.",
+              "Only they may amend signatures.",
+              "Used for reimbursements upon cleanup."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "guardianSignatures",
+            "docs": [
+              "Unverified guardian signatures."
+            ],
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  66
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "initializeArgs",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "rootExpiry",
+            "type": "u64"
+          },
+          {
+            "name": "allowedUpdateStaleness",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "latestRoot",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "readBlockNumber",
+            "docs": [
+              "Block number from which the root was read."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "readBlockHash",
+            "docs": [
+              "Block hash from which the root was read."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "readBlockTime",
+            "docs": [
+              "Block time (in microseconds) from which the root was read."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "root",
+            "docs": [
+              "Root hash of the last posted root account."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "verificationType",
+            "docs": [
+              "SEED: Verification type. Stored for off-chain convenience."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                1
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "root",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "bump",
+            "type": "u8"
+          },
+          {
+            "name": "readBlockNumber",
+            "docs": [
+              "Block number from which the root was read."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "readBlockHash",
+            "docs": [
+              "Block hash from which the root was read."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "readBlockTime",
+            "docs": [
+              "Block time (in microseconds) from which the root was read."
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "refundRecipient",
+            "docs": [
+              "Payer of this root account, used for reimbursements upon cleanup."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "root",
+            "docs": [
+              "SEED: Root hash. Stored for off-chain convenience."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "verificationType",
+            "docs": [
+              "SEED: Verification type. Stored for off-chain convenience."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                1
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "wormholeGuardianSet",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "index",
+            "docs": [
+              "Index representing an incrementing version number for this guardian set."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "keys",
+            "docs": [
+              "Ethereum-style public keys."
+            ],
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  20
+                ]
+              }
+            }
+          },
+          {
+            "name": "creationTime",
+            "docs": [
+              "Timestamp representing the time this guardian became active."
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "expirationTime",
+            "docs": [
+              "Expiration time when VAAs issued by this set are no longer valid."
+            ],
+            "type": "u32"
+          }
+        ]
+      }
+    }
+  ]
+};

--- a/tests/solana-world-id-onchain-template.ts
+++ b/tests/solana-world-id-onchain-template.ts
@@ -1,12 +1,15 @@
 import * as anchor from "@coral-xyz/anchor";
 import { Program } from "@coral-xyz/anchor";
-import { SolanaWorldIdOnchainTemplate } from "../target/types/solana_world_id_onchain_template";
-import fmtTest from "./helpers/fmtTest";
-import { assert, expect, use } from "chai";
-import { deriveRootKey } from "./helpers/root";
 import { PublicKey } from "@solana/web3.js";
+import { assert, expect, use } from "chai";
 import chaiAsPromised from "chai-as-promised";
+import worldIdIdl from "../idls/solana_world_id_program.json";
+import { SolanaWorldIdOnchainTemplate } from "../target/types/solana_world_id_onchain_template";
 import { deriveConfigKey } from "./helpers/config";
+import fmtTest from "./helpers/fmtTest";
+import { mockUpdateRoot } from "./helpers/mockUpdateRoot";
+import { deriveRootKey } from "./helpers/root";
+import { SolanaWorldIdProgram } from "./helpers/solana_world_id_program";
 
 use(chaiAsPromised);
 
@@ -14,6 +17,11 @@ describe("solana-world-id-onchain-template", () => {
   // Configure the client to use the local cluster.
   const provider = anchor.AnchorProvider.env();
   anchor.setProvider(anchor.AnchorProvider.env());
+
+  const worldIdProgram = new Program<SolanaWorldIdProgram>(
+    worldIdIdl as any,
+    provider
+  );
 
   const program = anchor.workspace
     .SolanaWorldIdOnchainTemplate as Program<SolanaWorldIdOnchainTemplate>;
@@ -80,6 +88,7 @@ describe("solana-world-id-onchain-template", () => {
       "Successfully verifies and adds nullifier PDA"
     ),
     async () => {
+      await mockUpdateRoot(worldIdProgram, rootHash);
       await expect(verifyAndExecute(rootHash, nullifierHash, proof, recipient))
         .to.be.fulfilled;
 


### PR DESCRIPTION
This PR adds a CI action for anchor test, cargo fmt, and cargo clippy. It also makes the necessary changes to support it passing.